### PR TITLE
Go 1.12.3 and 1.11.8 are released

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.11.7" \
+ENV GOLANG_VERSION="1.11.8" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8" \
+ENV GOLANG_DOWNLOAD_SHA256="e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.12.2" \
+ENV GOLANG_VERSION="1.12.3" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f" \
+ENV GOLANG_DOWNLOAD_SHA256="3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.12.minor