### PR TITLE
Go 1.12.4 and Go 1.11.9 are released

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.11.8" \
+ENV GOLANG_VERSION="1.11.9" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1" \
+ENV GOLANG_DOWNLOAD_SHA256="e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.12.3" \
+ENV GOLANG_VERSION="1.12.4" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df" \
+ENV GOLANG_DOWNLOAD_SHA256="d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \


### PR DESCRIPTION
Hahaha, I sometimes do it, too!

> Hello gophers,
>
> We have just released Go versions 1.12.4 and 1.11.9, minor point releases.
>
> These releases fix an issue where using the prebuilt binary releases on older versions of GNU/Linux led to failures when linking programs that used cgo.
>
> Only Linux users who hit this issue need to update.
>
> This was previously attempted with Go 1.12.3 and 1.11.8, but both were accidentally released without the intended fix. We apologize for the mixup on our part.
>
> View the release notes for more information:
>     https://golang.org/doc/devel/release.html#go1.12.minor
>
> You can download binary and source distributions from the Go web site:
>     https://golang.org/dl/
>
> To compile from source using a Git clone, update to the release with
> "git checkout go1.12.4" and build as usual.
>
> Thanks to everyone who contributed to the release.
>
> Thanks,
> Andy for the Go team
