### PR TITLE
Go 1.11.11 and 1.12.6 are released

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.11.10" \
+ENV GOLANG_VERSION="1.11.11" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="aefaa228b68641e266d1f23f1d95dba33f17552ba132878b65bb798ffa37e6d0" \
+ENV GOLANG_DOWNLOAD_SHA256="2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.12.5" \
+ENV GOLANG_VERSION="1.12.6" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf" \
+ENV GOLANG_DOWNLOAD_SHA256="dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \

--- a/update.pl
+++ b/update.pl
@@ -11,9 +11,8 @@ my @versions;
 my $pageToken = "";
 
 do {
-    my $json = decode_json(
-        `curl -fsSL "https://www.googleapis.com/storage/v1/b/golang/o?fields=nextPageToken,items%2Fname&pageToken=$pageToken"`
-    );
+    my $body = `curl -fsSL "https://www.googleapis.com/storage/v1/b/golang/o?fields=nextPageToken,items%2Fname&pageToken=$pageToken"`;
+    my $json = decode_json($body);
     push @versions, map {
         $_->{name} =~ /^go([.0-9]*)[.]src[.]tar[.]gz$/ ? ($1) : ()
     } @{$json->{items}};


### PR DESCRIPTION
> https://groups.google.com/forum/#!msg/golang-announce/dNU0sAdX65I/3psx7_OqAQAJ
> 
> Hello gophers,
> 
> We have just released Go versions 1.12.6 and 1.11.11, minor point releases.
> 
> These releases include fixes to the compiler, the linker, the go command,
> and the crypto/x509, net/http, and os packages.
> 
> View the release notes for more information:
>     https://golang.org/doc/devel/release.html#go1.12.minor
>     https://golang.org/doc/devel/release.html#go1.11.minor
> 
> You can download binary and source distributions from the Go web site:
>     https://golang.org/dl/
> 
> To compile Go 1.12.6 from source using a Git clone, update to the release
> with "git checkout go1.12.6" and build as usual.
> 
> Thanks to everyone who contributed to the releases.
> 
> Cheers,
> Dmitri for the Go team