### PR TITLE
Go 1.11.13 and 1.12.8 released

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.11.12" \
+ENV GOLANG_VERSION="1.11.13" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d" \
+ENV GOLANG_DOWNLOAD_SHA256="50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM ubuntu:18.04
 
-ENV GOLANG_VERSION="1.12.7" \
+ENV GOLANG_VERSION="1.12.8" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
 
@@ -114,7 +114,7 @@ COPY ssh_config /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9" \
+ENV GOLANG_DOWNLOAD_SHA256="bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2" \
     GOPATH="/go"
 RUN set -ex \
     && mkdir -p "$GOPATH/src" "$GOPATH/bin" \


### PR DESCRIPTION
> Hi gophers,
> 
> We have just released Go 1.12.8 and Go 1.11.13 to address recently reported security issues. We recommend that all users update to one of these releases (if you’re not sure which, choose Go 1.12.8).
> net/http: Denial of Service vulnerabilities in the HTTP/2 implementation
> 
> net/http and golang.org/x/net/http2 servers that accept direct connections from untrusted clients could be remotely made to allocate an unlimited amount of memory, until the program crashes. Servers will now close connections if the send queue accumulates too many control messages.
> The issues are CVE-2019-9512 and CVE-2019-9514, and Go issue golang.org/issue/33606.
> Thanks to Jonathan Looney from Netflix for discovering and reporting these issues.
> 
> This is also fixed in version v0.0.0-20190813141303-74dc4d7220e7 of golang.org/x/net/http2.
> net/url: parsing validation issue
> 
> url.Parse would accept URLs with malformed hosts, such that the Host field could have arbitrary suffixes that would appear in neither Hostname() nor Port(), allowing authorization bypasses in certain applications. Note that URLs with invalid, not numeric ports will now return an error from url.Parse.
> The issue is CVE-2019-14809 and Go issue golang.org/issue/29098.
> Thanks to Julian Hector and Nikolai Krein from Cure53, and Adi Cohen (adico.me) for discovering and reporting this issue.
> Downloads are available at https://golang.org/dl for all supported platforms.
> 
> Thank you,
> Dmitri on behalf of the Go team