### PR TITLE
stop building Go 1.11 images

### DIFF
--- a/.github/workflows/amazonlinux2-1.0.yml
+++ b/.github/workflows/amazonlinux2-1.0.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - "1.11"
           - "1.12"
           - "1.13"
     steps:

--- a/.github/workflows/amazonlinux2-2.0.yml
+++ b/.github/workflows/amazonlinux2-2.0.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - "1.11"
           - "1.12"
           - "1.13"
     steps:

--- a/.github/workflows/standard-1.0.yml
+++ b/.github/workflows/standard-1.0.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         golang:
-        - "1.11"
         - "1.12"
         - "1.13"
     steps:

--- a/.github/workflows/standard-2.0.yml
+++ b/.github/workflows/standard-2.0.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - "1.11"
           - "1.12"
           - "1.13"
     steps:

--- a/.github/workflows/standard-3.0.yml
+++ b/.github/workflows/standard-3.0.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - "1.11"
           - "1.12"
           - "1.13"
     steps:

--- a/README.md
+++ b/README.md
@@ -18,17 +18,14 @@ Docker Pull Command:
 # standard 1.0 based
 docker pull shogo82148/codebuild-golang:1.13-standard-1.0
 docker pull shogo82148/codebuild-golang:1.12-standard-1.0
-docker pull shogo82148/codebuild-golang:1.11-standard-1.0
 
 # standard 2.0 based
 docker pull shogo82148/codebuild-golang:1.13-standard-2.0
 docker pull shogo82148/codebuild-golang:1.12-standard-2.0
-docker pull shogo82148/codebuild-golang:1.11-standard-2.0
 
 # amazonlinux2-x86_64-standard 1.0 based
 docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-1.0
 docker pull shogo82148/codebuild-golang:1.12-amazonlinux2-1.0
-docker pull shogo82148/codebuild-golang:1.11-amazonlinux2-1.0
 ```
 
 ### An Example of CloudFormation Template for Creating CodeBuild Project

--- a/README.md
+++ b/README.md
@@ -23,9 +23,17 @@ docker pull shogo82148/codebuild-golang:1.12-standard-1.0
 docker pull shogo82148/codebuild-golang:1.13-standard-2.0
 docker pull shogo82148/codebuild-golang:1.12-standard-2.0
 
+# standard 3.0 based
+docker pull shogo82148/codebuild-golang:1.13-standard-3.0
+docker pull shogo82148/codebuild-golang:1.12-standard-3.0
+
 # amazonlinux2-x86_64-standard 1.0 based
 docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-1.0
 docker pull shogo82148/codebuild-golang:1.12-amazonlinux2-1.0
+
+# amazonlinux2-x86_64-standard 2.0 based
+docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-2.0
+docker pull shogo82148/codebuild-golang:1.12-amazonlinux2-2.0
 ```
 
 ### An Example of CloudFormation Template for Creating CodeBuild Project
@@ -38,7 +46,7 @@ docker pull shogo82148/codebuild-golang:1.12-amazonlinux2-1.0
         Type: NO_ARTIFACTS
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: shogo82148/codebuild-golang:1.13-standard-2.0
+        Image: shogo82148/codebuild-golang:1.13-standard-3.0
         Type: LINUX_CONTAINER
       ServiceRole: !GetAtt CodeBuildRole.Arn
       Source:

--- a/update.sh
+++ b/update.sh
@@ -2,46 +2,36 @@
 
 (
     cd ubuntu/1.0 \
-    && echo checking update for 1.11-standard-1.0 >&2 \
-    && ./update.pl 1.11 \
     && echo checking update for 1.12-standard-1.0 >&2 \
     && ./update.pl 1.12 \
     && echo checking update for 1.13-standard-1.0 >&2 \
     && ./update.pl 1.13
-)
+) || exit 1
 (
     cd ubuntu/2.0 \
-    && echo checking update for 1.11-standard-2.0 >&2 \
-    && ./update.pl 1.11 \
     && echo checking update for 1.12-standard-2.0 >&2 \
     && ./update.pl 1.12 \
     && echo checking update for 1.13-standard-2.0 >&2 \
     && ./update.pl 1.13
-)
+) || exit 1
 (
     cd ubuntu/3.0 \
-    && echo checking update for 1.11-standard-3.0 >&2 \
-    && ./update.pl 1.11 \
     && echo checking update for 1.12-standard-3.0 >&2 \
     && ./update.pl 1.12 \
     && echo checking update for 1.13-standard-3.0 >&2 \
     && ./update.pl 1.13
-)
+) || exit 1
 (
     cd al2/1.0 \
-    && echo checking update for 1.11-amazonlinux2-1.0 >&2 \
-    && ./update.pl 1.11 \
     && echo checking update for 1.12-amazonlinux2-1.0 >&2 \
     && ./update.pl 1.12 \
     && echo checking update for 1.13-amazonlinux2-1.0 >&2 \
     && ./update.pl 1.13
-)
+) || exit 1
 (
     cd al2/2.0 \
-    && echo checking update for 1.11-amazonlinux2-2.0 >&2 \
-    && ./update.pl 1.11 \
     && echo checking update for 1.12-amazonlinux2-2.0 >&2 \
     && ./update.pl 1.12 \
     && echo checking update for 1.13-amazonlinux2-2.0 >&2 \
     && ./update.pl 1.13
-)
+) || exit 1


### PR DESCRIPTION
Go 1.11 is no longer supported.
See [release policy](https://golang.org/doc/devel/release.html#policy) of Golang