### PR TITLE
drop support of Go 1.13

### DIFF
--- a/.github/workflows/amazonlinux2-1.0.yml
+++ b/.github/workflows/amazonlinux2-1.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-amazonlinux2-1.0"

--- a/.github/workflows/amazonlinux2-2.0.yml
+++ b/.github/workflows/amazonlinux2-2.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-amazonlinux2-2.0"

--- a/.github/workflows/amazonlinux2-3.0.yml
+++ b/.github/workflows/amazonlinux2-3.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-amazonlinux2-3.0"

--- a/.github/workflows/standard-1.0.yml
+++ b/.github/workflows/standard-1.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-standard-1.0"

--- a/.github/workflows/standard-2.0.yml
+++ b/.github/workflows/standard-2.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-standard-2.0"

--- a/.github/workflows/standard-3.0.yml
+++ b/.github/workflows/standard-3.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-standard-3.0"

--- a/.github/workflows/standard-4.0.yml
+++ b/.github/workflows/standard-4.0.yml
@@ -21,7 +21,6 @@ jobs:
         golang:
           - "1.15"
           - "1.14"
-          - "1.13"
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-env name=TAG::${{ secrets.username }}/codebuild-golang:${{ matrix.golang }}-standard-4.0"

--- a/README.md
+++ b/README.md
@@ -16,32 +16,32 @@ Docker Pull Command:
 
 ```bash
 # standard 1.0 based
+docker pull shogo82148/codebuild-golang:1.15-standard-1.0
 docker pull shogo82148/codebuild-golang:1.14-standard-1.0
-docker pull shogo82148/codebuild-golang:1.13-standard-1.0
 
 # standard 2.0 based
+docker pull shogo82148/codebuild-golang:1.15-standard-2.0
 docker pull shogo82148/codebuild-golang:1.14-standard-2.0
-docker pull shogo82148/codebuild-golang:1.13-standard-2.0
 
 # standard 3.0 based
+docker pull shogo82148/codebuild-golang:1.15-standard-3.0
 docker pull shogo82148/codebuild-golang:1.14-standard-3.0
-docker pull shogo82148/codebuild-golang:1.13-standard-3.0
 
 # standard 4.0 based
+docker pull shogo82148/codebuild-golang:1.15-standard-4.0
 docker pull shogo82148/codebuild-golang:1.14-standard-4.0
-docker pull shogo82148/codebuild-golang:1.13-standard-4.0
 
 # amazonlinux2-x86_64-standard 1.0 based
+docker pull shogo82148/codebuild-golang:1.15-amazonlinux2-1.0
 docker pull shogo82148/codebuild-golang:1.14-amazonlinux2-1.0
-docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-1.0
 
 # amazonlinux2-x86_64-standard 2.0 based
+docker pull shogo82148/codebuild-golang:1.15-amazonlinux2-2.0
 docker pull shogo82148/codebuild-golang:1.14-amazonlinux2-2.0
-docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-2.0
 
 # amazonlinux2-x86_64-standard 3.0 based
+docker pull shogo82148/codebuild-golang:1.15-amazonlinux2-3.0
 docker pull shogo82148/codebuild-golang:1.14-amazonlinux2-3.0
-docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-3.0
 ```
 
 ### An Example of CloudFormation Template for Creating CodeBuild Project
@@ -54,7 +54,7 @@ docker pull shogo82148/codebuild-golang:1.13-amazonlinux2-3.0
         Type: NO_ARTIFACTS
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: shogo82148/codebuild-golang:1.14-standard-4.0
+        Image: shogo82148/codebuild-golang:1.15-standard-4.0
         Type: LINUX_CONTAINER
       ServiceRole: !GetAtt CodeBuildRole.Arn
       Source:

--- a/update.sh
+++ b/update.sh
@@ -2,8 +2,6 @@
 
 (
     cd ubuntu/1.0 \
-    && echo checking update for 1.13-standard-1.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-standard-1.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-standard-1.0 >&2 \
@@ -11,8 +9,6 @@
 ) || exit 1
 (
     cd ubuntu/2.0 \
-    && echo checking update for 1.13-standard-2.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-standard-2.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-standard-2.0 >&2 \
@@ -20,8 +16,6 @@
 ) || exit 1
 (
     cd ubuntu/3.0 \
-    && echo checking update for 1.13-standard-3.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-standard-3.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-standard-3.0 >&2 \
@@ -29,8 +23,6 @@
 ) || exit 1
 (
     cd ubuntu/4.0 \
-    && echo checking update for 1.13-standard-4.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-standard-4.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-standard-4.0 >&2 \
@@ -38,8 +30,6 @@
 ) || exit 1
 (
     cd al2/1.0 \
-    && echo checking update for 1.13-amazonlinux2-1.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-amazonlinux2-1.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-amazonlinux2-1.0 >&2 \
@@ -47,8 +37,6 @@
 ) || exit 1
 (
     cd al2/2.0 \
-    && echo checking update for 1.13-amazonlinux2-2.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-amazonlinux2-2.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-amazonlinux2-2.0 >&2 \
@@ -56,8 +44,6 @@
 ) || exit 1
 (
     cd al2/3.0 \
-    && echo checking update for 1.13-amazonlinux2-3.0 >&2 \
-    && ./update.pl 1.13 \
     && echo checking update for 1.14-amazonlinux2-3.0 >&2 \
     && ./update.pl 1.14 \
     && echo checking update for 1.15-amazonlinux2-3.0 >&2 \


### PR DESCRIPTION
Go 1.13 will not be updated because of the Golang's Release Policy.
https://golang.org/doc/devel/release.html#policy