### PR TITLE
bump Go 1.23

### DIFF
--- a/.github/workflows/amazonlinux2-2.0.yml
+++ b/.github/workflows/amazonlinux2-2.0.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          .github/build.sh 1.23
           .github/build.sh 1.22
-          .github/build.sh 1.21
         env:
           USERNAME: ${{ secrets.username }}
           PASSWORD: ${{ secrets.password }}

--- a/.github/workflows/amazonlinux2-3.0.yml
+++ b/.github/workflows/amazonlinux2-3.0.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          .github/build.sh 1.23
           .github/build.sh 1.22
-          .github/build.sh 1.21
         env:
           USERNAME: ${{ secrets.username }}
           PASSWORD: ${{ secrets.password }}

--- a/.github/workflows/standard-3.0.yml
+++ b/.github/workflows/standard-3.0.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          .github/build.sh 1.23
           .github/build.sh 1.22
-          .github/build.sh 1.21
         env:
           USERNAME: ${{ secrets.username }}
           PASSWORD: ${{ secrets.password }}

--- a/.github/workflows/standard-4.0.yml
+++ b/.github/workflows/standard-4.0.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          .github/build.sh 1.23
           .github/build.sh 1.22
-          .github/build.sh 1.21
         env:
           USERNAME: ${{ secrets.username }}
           PASSWORD: ${{ secrets.password }}

--- a/.github/workflows/standard-5.0.yml
+++ b/.github/workflows/standard-5.0.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          .github/build.sh 1.23
           .github/build.sh 1.22
-          .github/build.sh 1.21
         env:
           USERNAME: ${{ secrets.username }}
           PASSWORD: ${{ secrets.password }}

--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@ Docker Pull Command:
 
 ```bash
 # standard 5.0 based
+docker pull shogo82148/codebuild-golang:1.23-standard-5.0
 docker pull shogo82148/codebuild-golang:1.22-standard-5.0
-docker pull shogo82148/codebuild-golang:1.21-standard-5.0
 
 # standard 4.0 based
+docker pull shogo82148/codebuild-golang:1.23-standard-4.0
 docker pull shogo82148/codebuild-golang:1.22-standard-4.0
-docker pull shogo82148/codebuild-golang:1.21-standard-4.0
 
 # standard 3.0 based
+docker pull shogo82148/codebuild-golang:1.23-standard-3.0
 docker pull shogo82148/codebuild-golang:1.22-standard-3.0
-docker pull shogo82148/codebuild-golang:1.21-standard-3.0
 
 # amazonlinux2-x86_64-standard 3.0 based
+docker pull shogo82148/codebuild-golang:1.23-amazonlinux2-3.0
 docker pull shogo82148/codebuild-golang:1.22-amazonlinux2-3.0
-docker pull shogo82148/codebuild-golang:1.21-amazonlinux2-3.0
 
 # amazonlinux2-x86_64-standard 2.0 based
+docker pull shogo82148/codebuild-golang:1.23-amazonlinux2-2.0
 docker pull shogo82148/codebuild-golang:1.22-amazonlinux2-2.0
-docker pull shogo82148/codebuild-golang:1.21-amazonlinux2-2.0
 ```
 
 ### An Example of CloudFormation Template for Creating CodeBuild Project
@@ -47,7 +47,7 @@ CodeBuildProject:
       Type: NO_ARTIFACTS
     Environment:
       ComputeType: BUILD_GENERAL1_SMALL
-      Image: shogo82148/codebuild-golang:1.22-standard-5.0
+      Image: shogo82148/codebuild-golang:1.23-standard-5.0
       Type: LINUX_CONTAINER
     ServiceRole: !GetAtt CodeBuildRole.Arn
     Source:

--- a/al2/2.0/go1.23/Dockerfile
+++ b/al2/2.0/go1.23/Dockerfile
@@ -1,0 +1,135 @@
+# Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+#****************        Utilities     ********************************************* 
+ENV JQ_VERSION="1.6" \
+    JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44" \
+    DOCKER_VERSION="19.03.3" \
+    DOCKER_SHA256="c3c8833e227b61fe6ce0bc5c17f97fa547035bef4ef17cf6601f30b0f20f4ce5" \
+    DOCKER_COMPOSE_VERSION="1.24.0" \
+    DOCKER_BUCKET="download.docker.com" \
+    DOCKER_CHANNEL="stable" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \    
+    GITVERSION_VERSION="4.0.0" \
+    DEBIAN_FRONTEND="noninteractive" \
+    SRC_DIR="/usr/src"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && yum install -y openssh-clients \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && yum groupinstall -y "Development tools" \
+    && yum install -y \
+           GeoIP-devel ImageMagick asciidoc bzip2-devel bzr bzrtools cvs cvsps \
+           docbook-dtds docbook-style-xsl dpkg-dev e2fsprogs expat-devel expect fakeroot \
+           glib2-devel groff gzip icu iptables krb5-server libargon2-devel \
+           libcurl-devel libdb-devel libedit-devel libevent-devel libffi-devel \
+           libicu-devel libjpeg-devel libpng-devel libserf libsqlite3x-devel \
+           libtidy-devel libunwind libwebp-devel libxml2-devel libxslt libxslt-devel \
+           libyaml-devel libzip-devel mariadb-devel mercurial mlocate \
+           ncurses-devel oniguruma-devel openssl openssl-devel perl-DBD-SQLite \
+           perl-DBI perl-HTTP-Date perl-IO-Pty-Easy perl-TimeDate perl-YAML-LibYAML \
+           postgresql-devel procps-ng python-configobj readline-devel rsync sgml-common \
+           subversion-perl tar tcl tk vim wget which xfsprogs xmlto xorg-x11-server-Xvfb xz-devel \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all \
+    && wget https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /usr/local/bin/jq \
+    && echo "$JQ_SHA256 /usr/local/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/local/bin/jq
+
+# Install Git
+RUN set -ex \
+   && GIT_VERSION=2.26.2 \
+   && GIT_TAR_FILE=git-$GIT_VERSION.tar.gz \
+   && GIT_SRC=https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz  \
+   && curl -L -o $GIT_TAR_FILE $GIT_SRC \
+   && tar zxvf $GIT_TAR_FILE \
+   && cd git-$GIT_VERSION \
+   && make -j4 prefix=/usr \
+   && make install prefix=/usr \
+   && cd .. ; rm -rf git-$GIT_VERSION \
+   && rm -rf $GIT_TAR_FILE /tmp/*
+
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && groupadd dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html
+RUN curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator \
+ && curl -sS -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl \
+ && curl -sS -o /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+ && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli
+
+VOLUME /var/lib/docker
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+
+COPY runtimes.yml /codebuild/image/config/runtimes.yml
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+#**************** PYTHON *****************************************************
+ENV PYTHON_38_VERSION="3.8.10" \
+    PYTHON_PIP_VERSION="21.1.2" \
+    PYYAML_VERSION="5.4.1"
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"
+COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
+RUN set -ex \
+    && env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_38_VERSION \
+    && rm -rf /tmp/* \
+    && pyenv global $PYTHON_38_VERSION \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli awscli boto3 pipenv virtualenv
+
+#****************     GO     **********************************************************
+ENV GOLANG_VERSION="1.23.4" \
+    GOLANG_DOWNLOAD_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.4" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && wget "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+#****************     END GO     **********************************************************
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/al2/2.0/go1.23/dockerd-entrypoint.sh
+++ b/al2/2.0/go1.23/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/al2/2.0/go1.23/runtimes.yml
+++ b/al2/2.0/go1.23/runtimes.yml
@@ -1,0 +1,13 @@
+version: 0.1
+
+runtimes:
+  golang:
+    versions:
+      1.23:
+        commands:
+          - echo "Installing Go version 1.23 ..."
+  docker:
+    versions:
+      18:
+        commands:
+          - echo "Installing Docker version 18 ..."

--- a/al2/2.0/go1.23/ssh_config
+++ b/al2/2.0/go1.23/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/al2/2.0/go1.23/tools/runtime_configs/python/3.8.10
+++ b/al2/2.0/go1.23/tools/runtime_configs/python/3.8.10
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.8.10
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/al2/3.0/go1.23/Dockerfile
+++ b/al2/3.0/go1.23/Dockerfile
@@ -1,0 +1,139 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+ENV EPEL_REPO="https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm" \
+    JQ_VERSION="1.6" \
+    JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && yum install -y openssh-clients \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && yum install -y $EPEL_REPO \
+    && yum groupinstall -y "Development tools" \
+    && yum install -y \
+           GeoIP-devel ImageMagick asciidoc bzip2-devel bzr bzrtools cvs cvsps \
+           docbook-dtds docbook-style-xsl dpkg-dev e2fsprogs expat-devel expect fakeroot \
+           glib2-devel groff gzip icu iptables krb5-server libargon2-devel \
+           libcurl-devel libdb-devel libedit-devel libevent-devel libffi-devel \
+           libicu-devel libjpeg-devel libpng-devel libserf libsqlite3x-devel \
+           libtidy-devel libunwind libwebp-devel libxml2-devel libxslt libxslt-devel \
+           libyaml-devel libzip-devel mariadb-devel mercurial mlocate \
+           ncurses-devel oniguruma-devel openssl openssl-devel perl-DBD-SQLite \
+           perl-DBI perl-HTTP-Date perl-IO-Pty-Easy perl-TimeDate perl-YAML-LibYAML \
+           postgresql-devel procps-ng python-configobj readline-devel rsync sgml-common \
+           subversion-perl tar tcl tk vim wget which xfsprogs xmlto xorg-x11-server-Xvfb xz-devel \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all \
+    && wget https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /usr/local/bin/jq \
+    && echo "$JQ_SHA256 /usr/local/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/local/bin/jq
+
+RUN useradd codebuild-user
+
+#=======================End of layer: core  =================
+
+# Install Git
+RUN set -ex \
+   && GIT_VERSION=2.27.0 \
+   && GIT_TAR_FILE=git-$GIT_VERSION.tar.gz \
+   && GIT_SRC=https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz  \
+   && curl -L -o $GIT_TAR_FILE $GIT_SRC \
+   && tar zxvf $GIT_TAR_FILE \
+   && cd git-$GIT_VERSION \
+   && make -j4 prefix=/usr \
+   && make install prefix=/usr \
+   && cd .. ; rm -rf git-$GIT_VERSION \
+   && rm -rf $GIT_TAR_FILE /tmp/* \
+# AWS Tools
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html
+    && curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator \
+    && curl -sS -o /usr/local/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/kubectl \
+    && curl -sS -o /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+    && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli \
+# Configure SSM
+    && yum install -y https://ec2-downloads-windows.s3.amazonaws.com/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all
+
+# Install env tools for runtimes
+
+##python
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"
+
+#=======================End of layer: tools  =================
+
+#Docker 19
+ENV DOCKER_BUCKET="download.docker.com" \
+    DOCKER_CHANNEL="stable" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \
+    DOCKER_COMPOSE_VERSION="1.26.0" \
+    DOCKER_SHA256="0f4336378f61ed73ed55a356ac19e46699a995f2aff34323ba5874d131548b9e" \
+    DOCKER_VERSION="19.03.11"
+
+VOLUME /var/lib/docker
+
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && groupadd dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget -nv "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+    && docker-compose version
+
+#Python 3.8
+ENV PYTHON_38_VERSION="3.8.10" \
+    PYTHON_PIP_VERSION="21.1.2" \
+    PYYAML_VERSION="5.4.1"
+
+COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
+RUN set -ex \
+    && env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_38_VERSION && rm -rf /tmp/* \
+    && pyenv global  $PYTHON_38_VERSION \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli awscli boto3 pipenv virtualenv
+
+#=======================End of layer: runtimes_2  =================
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+COPY runtimes.yml /codebuild/image/config/runtimes.yml
+COPY dockerd-entrypoint.sh /usr/local/bin/
+COPY amazon-ssm-agent.json          /etc/amazon/ssm/
+
+#=======================End of layer: al2_v3  =================
+
+#****************     GO     **********************************************************
+ENV GOLANG_VERSION="1.23.4" \
+    GOLANG_DOWNLOAD_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.4" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && wget "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+#****************     END GO     **********************************************************
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/al2/3.0/go1.23/amazon-ssm-agent.json
+++ b/al2/3.0/go1.23/amazon-ssm-agent.json
@@ -1,0 +1,45 @@
+{
+    "Profile":{
+        "ShareCreds" : true,
+        "ShareProfile" : ""
+    },
+    "Mds": {
+        "CommandWorkersLimit" : 5,
+        "StopTimeoutMillis" : 20000,
+        "Endpoint": "",
+        "CommandRetryLimit": 15
+    },
+    "Ssm": {
+        "Endpoint": "",
+        "HealthFrequencyMinutes": 5,
+        "CustomInventoryDefaultLocation" : "",
+        "AssociationLogsRetentionDurationHours" : 24,
+        "RunCommandLogsRetentionDurationHours" : 336,
+        "SessionLogsRetentionDurationHours" : 336
+    },
+    "Mgs": {
+        "Region": "",
+        "Endpoint": "",
+        "StopTimeoutMillis" : 20000,
+        "SessionWorkersLimit" : 1000
+    },
+    "Agent": {
+        "Region": "",
+        "OrchestrationRootDir": "",
+        "ContainerMode": true
+    },
+    "Os": {
+        "Lang": "en-US",
+        "Name": "",
+        "Version": "1"
+    },
+    "S3": {
+        "Endpoint": "",
+        "Region": "",
+        "LogBucket":"",
+        "LogKey":""
+    },
+    "Kms": {
+        "Endpoint": ""
+    }
+}

--- a/al2/3.0/go1.23/dockerd-entrypoint.sh
+++ b/al2/3.0/go1.23/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 >/var/log/docker.log 2>&1 &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/al2/3.0/go1.23/runtimes.yml
+++ b/al2/3.0/go1.23/runtimes.yml
@@ -1,0 +1,16 @@
+version: 0.1
+
+runtimes:
+  golang:
+    versions:
+      1.23:
+        commands:
+          - echo "Installing Go version 1.23 ..."
+  docker:
+    versions:
+      18:
+        commands:
+          - echo "Using Docker 19"
+      19:
+        commands:
+          - echo "Using Docker 19"

--- a/al2/3.0/go1.23/ssh_config
+++ b/al2/3.0/go1.23/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/al2/3.0/go1.23/tools/runtime_configs/python/3.8.10
+++ b/al2/3.0/go1.23/tools/runtime_configs/python/3.8.10
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.8.10
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/ubuntu/3.0/go1.23/Dockerfile
+++ b/ubuntu/3.0/go1.23/Dockerfile
@@ -1,0 +1,141 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
+
+#****************        Utilities     ********************************************* 
+ENV DOCKER_VERSION="19.03.3" \
+    DOCKER_SHA256="c3c8833e227b61fe6ce0bc5c17f97fa547035bef4ef17cf6601f30b0f20f4ce5" \
+    DOCKER_COMPOSE_VERSION="1.24.0" \
+    DOCKER_BUCKET="download.docker.com" \    
+    DOCKER_CHANNEL="stable" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \    
+    GITVERSION_VERSION="4.0.0" \
+    JQ_VERSION="1.6" \
+    JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44" \
+    DEBIAN_FRONTEND="noninteractive" \
+    SRC_DIR="/usr/src"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
+    && apt-get update \
+    && apt install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install software-properties-common -y --no-install-recommends \
+    && apt-add-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install git=1:2.* -y --no-install-recommends \
+    && git version \
+    && apt-get install -y --no-install-recommends openssh-client \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && apt-get install -y --no-install-recommends \
+       wget python3 python3-dev python3-pip python3-setuptools fakeroot ca-certificates \
+       netbase gnupg dirmngr bzr mercurial procps \
+       tar gzip zip autoconf automake \
+       bzip2 file g++ gcc imagemagick \
+       libbz2-dev libc6-dev libcurl4-openssl-dev libdb-dev \
+       libevent-dev libffi-dev libgeoip-dev libglib2.0-dev \
+       libjpeg-dev libkrb5-dev liblzma-dev \
+       libmagickcore-dev libmagickwand-dev libmysqlclient-dev \
+       libncurses5-dev libpq-dev libreadline-dev \
+       libsqlite3-dev libssl-dev libtool libwebp-dev \
+       libxml2-dev libxslt1-dev libyaml-dev make \
+       patch xz-utils zlib1g-dev unzip curl \
+       e2fsprogs iptables xfsprogs \
+       less groff liberror-perl \
+       asciidoc build-essential bzr cvs cvsps docbook-xml docbook-xsl dpkg-dev \
+       libdbd-sqlite3-perl libdbi-perl libdpkg-perl libhttp-date-perl \
+       libio-pty-perl libserf-1-1 libsvn-perl libsvn1 libtcl8.6 libtimedate-perl \
+       libxml2-utils libyaml-perl python-bzrlib python-configobj \
+       sgml-base sgml-data subversion tcl tcl8.6 xml-core xmlto xsltproc \
+       tk gettext gettext-base libapr1 libaprutil1 xvfb expect parallel \
+       locales rsync \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && wget https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /usr/local/bin/jq \
+    && echo "$JQ_SHA256 /usr/local/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/local/bin/jq
+
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html
+RUN curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator \
+    && curl -sS -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl \
+    && curl -sS -o /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+    && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli
+
+#**************** PYTHON *****************************************************
+ENV PYTHON_38_VERSION="3.8.10" \
+    PYTHON_PIP_VERSION="21.1.2" \
+    PYYAML_VERSION="5.4.1"
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"
+COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
+RUN set -ex \
+    && env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_38_VERSION \
+    && rm -rf /tmp/* \
+    && pyenv global $PYTHON_38_VERSION \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli awscli boto3 pipenv virtualenv
+
+VOLUME /var/lib/docker
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+
+COPY runtimes.yml /codebuild/image/config/runtimes.yml
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+#****************     GO     **********************************************************
+ENV GOLANG_VERSION="1.23.4" \
+    GOLANG_DOWNLOAD_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.1" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+    && apt-get clean \
+    && wget "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+#****************     END GO     **********************************************************

--- a/ubuntu/3.0/go1.23/dockerd-entrypoint.sh
+++ b/ubuntu/3.0/go1.23/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/ubuntu/3.0/go1.23/runtimes.yml
+++ b/ubuntu/3.0/go1.23/runtimes.yml
@@ -1,0 +1,13 @@
+version: 0.1
+
+runtimes:
+  golang:
+    versions:
+      1.23:
+        commands:
+          - echo "Installing Go version 1.23 ..."
+  docker:
+    versions:
+      18:
+        commands:
+          - echo "Installing Docker version 18 ..."

--- a/ubuntu/3.0/go1.23/ssh_config
+++ b/ubuntu/3.0/go1.23/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/ubuntu/3.0/go1.23/tools/runtime_configs/python/3.8.10
+++ b/ubuntu/3.0/go1.23/tools/runtime_configs/python/3.8.10
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.8.10
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/ubuntu/4.0/go1.23/Dockerfile
+++ b/ubuntu/4.0/go1.23/Dockerfile
@@ -1,0 +1,153 @@
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    JQ_VERSION="1.6" \
+    JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
+    && apt-get update \
+    && apt install -y apt-transport-https gnupg ca-certificates \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+    && apt-get install software-properties-common -y --no-install-recommends \
+    && apt-add-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install git=1:2.* -y --no-install-recommends \
+    && git version \
+    && apt-get install -y --no-install-recommends openssh-client \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && apt-get install -y --no-install-recommends \
+          apt-utils asciidoc autoconf automake build-essential bzip2 \
+          bzr curl cvs cvsps dirmngr docbook-xml docbook-xsl dpkg-dev \
+          e2fsprogs expect fakeroot file g++ gcc gettext gettext-base \
+          git groff gzip imagemagick iptables less libapr1 libaprutil1 \
+          libargon2-0-dev libbz2-dev libc6-dev libcurl4-openssl-dev \
+          libdb-dev libdbd-sqlite3-perl libdbi-perl libdpkg-perl \
+          libedit-dev liberror-perl libevent-dev libffi-dev libgeoip-dev \
+          libglib2.0-dev libhttp-date-perl libio-pty-perl libjpeg-dev \
+          libkrb5-dev liblzma-dev libmagickcore-dev libmagickwand-dev \
+          libmysqlclient-dev libncurses5-dev libncursesw5-dev libonig-dev \
+          libpq-dev libreadline-dev libserf-1-1 libsqlite3-dev libssl-dev \
+          libsvn1 libsvn-perl libtcl8.6 libtidy-dev libtimedate-perl \
+          libtool libwebp-dev libxml2-dev libxml2-utils libxslt1-dev \
+          libyaml-dev libyaml-perl llvm locales make mercurial mlocate \
+          netbase openssl patch pkg-config procps python-bzrlib \
+          python-configobj python-openssl rsync sgml-base sgml-data subversion \
+          tar tcl tcl8.6 tk tk-dev unzip wget xfsprogs xml-core xmlto xsltproc \
+          libzip4 libzip-dev vim xvfb xz-utils zip zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && wget https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /usr/local/bin/jq \
+    && echo "$JQ_SHA256 /usr/local/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/local/bin/jq
+
+RUN useradd codebuild-user
+
+#=======================End of layer: core  =================
+
+# AWS Tools
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html
+RUN set -ex \
+    && curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator \
+    && curl -sS -o /usr/local/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/kubectl \
+    && curl -sS -o /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+    && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli \
+# Configure SSM
+    && mkdir /tmp/ssm \
+    && cd /tmp/ssm \
+    && wget https://ec2-downloads-windows.s3.amazonaws.com/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb \
+    && dpkg -i amazon-ssm-agent.deb \
+    && cd && rm -rf /tmp/ssm
+
+# Install env tools for runtimes
+
+#python
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"
+
+#=======================End of layer: tools  =================
+
+#**************** PYTHON *****************************************************
+ENV PYTHON_38_VERSION="3.8.10" \
+    PYTHON_PIP_VERSION="21.1.2" \
+    PYYAML_VERSION="5.4.1"
+COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
+RUN set -ex \
+    && env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_38_VERSION \
+    && rm -rf /tmp/* \
+    && pyenv global $PYTHON_38_VERSION \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli awscli boto3 pipenv virtualenv
+
+#**************** END PYTHON *****************************************************
+
+#****************        DOCKER    *********************************************
+ENV DOCKER_BUCKET="download.docker.com" \
+    DOCKER_CHANNEL="stable" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \
+    DOCKER_COMPOSE_VERSION="1.26.0" \
+    SRC_DIR="/usr/src" \
+    DOCKER_SHA256="0f4336378f61ed73ed55a356ac19e46699a995f2aff34323ba5874d131548b9e" \
+    DOCKER_VERSION="19.03.11"
+
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget -nv "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+VOLUME /var/lib/docker
+#*********************** END  DOCKER  ****************************
+
+#=======================End of layer: runtimes  =================
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+COPY runtimes.yml /codebuild/image/config/runtimes.yml
+COPY dockerd-entrypoint.sh /usr/local/bin/
+COPY amazon-ssm-agent.json          /etc/amazon/ssm/
+
+#=======================END of STD:4.0  =================
+
+#****************     GO     **********************************************************
+ENV GOLANG_VERSION="1.23.4" \
+    GOLANG_DOWNLOAD_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.4" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+    && apt-get clean \
+    && wget "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+#****************     END GO     **********************************************************
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/ubuntu/4.0/go1.23/amazon-ssm-agent.json
+++ b/ubuntu/4.0/go1.23/amazon-ssm-agent.json
@@ -1,0 +1,45 @@
+{
+    "Profile":{
+        "ShareCreds" : true,
+        "ShareProfile" : ""
+    },
+    "Mds": {
+        "CommandWorkersLimit" : 5,
+        "StopTimeoutMillis" : 20000,
+        "Endpoint": "",
+        "CommandRetryLimit": 15
+    },
+    "Ssm": {
+        "Endpoint": "",
+        "HealthFrequencyMinutes": 5,
+        "CustomInventoryDefaultLocation" : "",
+        "AssociationLogsRetentionDurationHours" : 24,
+        "RunCommandLogsRetentionDurationHours" : 336,
+        "SessionLogsRetentionDurationHours" : 336
+    },
+    "Mgs": {
+        "Region": "",
+        "Endpoint": "",
+        "StopTimeoutMillis" : 20000,
+        "SessionWorkersLimit" : 1000
+    },
+    "Agent": {
+        "Region": "",
+        "OrchestrationRootDir": "",
+        "ContainerMode": true
+    },
+    "Os": {
+        "Lang": "en-US",
+        "Name": "",
+        "Version": "1"
+    },
+    "S3": {
+        "Endpoint": "",
+        "Region": "",
+        "LogBucket":"",
+        "LogKey":""
+    },
+    "Kms": {
+        "Endpoint": ""
+    }
+}

--- a/ubuntu/4.0/go1.23/dockerd-entrypoint.sh
+++ b/ubuntu/4.0/go1.23/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/ubuntu/4.0/go1.23/runtimes.yml
+++ b/ubuntu/4.0/go1.23/runtimes.yml
@@ -1,0 +1,17 @@
+version: 0.1
+
+runtimes:
+
+  golang:
+    versions:
+      1.23:
+        commands:
+          - echo "Installing Go version 1.23 ..."
+  docker:
+    versions:
+      18:
+        commands:
+          - echo "Using Docker 19"
+      19:
+        commands:
+          - echo "Using Docker 19"

--- a/ubuntu/4.0/go1.23/ssh_config
+++ b/ubuntu/4.0/go1.23/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/ubuntu/4.0/go1.23/tools/runtime_configs/python/3.8.10
+++ b/ubuntu/4.0/go1.23/tools/runtime_configs/python/3.8.10
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.8.10
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/ubuntu/5.0/go1.23/Dockerfile
+++ b/ubuntu/5.0/go1.23/Dockerfile
@@ -1,0 +1,144 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+FROM public.ecr.aws/ubuntu/ubuntu:20.04
+
+#****************        Utilities     ********************************************* 
+ENV DOCKER_VERSION="19.03.13" \
+    DOCKER_COMPOSE_VERSION="1.27.4" \
+    DOCKER_BUCKET="download.docker.com" \    
+    DOCKER_CHANNEL="stable" \
+    DOCKER_SHA256="ddb13aff1fcdcceb710bf71a210169b9c1abfd7420eeaf42cf7975f8fae2fcc8" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \    
+    JQ_VERSION="1.6" \
+    JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44" \
+    DEBIAN_FRONTEND="noninteractive" \
+    SRC_DIR="/usr/src"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
+    && apt-get update \
+    && apt install -y apt-transport-https gnupg ca-certificates \
+    && apt-get install software-properties-common -y --no-install-recommends \
+    && apt-add-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install git=1:2.* -y --no-install-recommends \
+    && git version \
+    && apt-get install -y --no-install-recommends openssh-client \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && apt-get install -y --no-install-recommends \
+        apt-utils asciidoc autoconf automake build-essential bzip2 \
+        bzr curl cvs cvsps dirmngr docbook-xml docbook-xsl dpkg-dev \
+        e2fsprogs expect fakeroot file g++ gcc gettext gettext-base \
+        groff gzip iptables less libapr1 libaprutil1 \
+        libargon2-0-dev libbz2-dev libc6-dev libcurl4-openssl-dev \
+        libdb-dev libdbd-sqlite3-perl libdbi-perl libdpkg-perl \
+        libedit-dev liberror-perl libevent-dev libffi-dev libgeoip-dev \
+        libglib2.0-dev libhttp-date-perl libio-pty-perl libjpeg-dev \
+        libkrb5-dev liblzma-dev libmagickcore-dev libmagickwand-dev \
+        libmysqlclient-dev libncurses5-dev libncursesw5-dev libonig-dev \
+        libpq-dev libreadline-dev libserf-1-1 libsqlite3-dev libssl-dev \
+        libsvn1 libsvn-perl libtcl8.6 libtidy-dev libtimedate-perl \
+        libtool libwebp-dev libxml2-dev libxml2-utils libxslt1-dev \
+        libyaml-dev libyaml-perl llvm locales make mercurial mlocate \
+        netbase openssl patch pkg-config procps python3-configobj \
+        python-openssl rsync sgml-base sgml-data \
+        tar tcl tcl8.6 tk tk-dev unzip wget xfsprogs xml-core xmlto xsltproc \
+        libzip5 libzip-dev vim xvfb xz-utils zip zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && wget https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /usr/local/bin/jq \
+    && echo "$JQ_SHA256 /usr/local/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/local/bin/jq
+
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html
+RUN curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator \
+    && curl -sS -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/kubectl \
+    && curl -sS -o /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+    && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+# Install AWS CLI v2
+# https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip \
+    && unzip /tmp/awscliv2.zip -d /opt \
+    && /opt/aws/install -i /usr/local/aws-cli -b /usr/local/bin \
+    && rm /tmp/awscliv2.zip \
+    && rm -rf /opt/aws \
+    && aws --version
+
+#**************** PYTHON *****************************************************
+ENV PYTHON_39_VERSION="3.9.5" \
+    PYTHON_PIP_VERSION="21.1.2" \
+    PYYAML_VERSION="5.4.1"
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"
+COPY tools/runtime_configs/python/$PYTHON_39_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_39_VERSION
+RUN set -ex \
+    && env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_39_VERSION \
+    && rm -rf /tmp/* \
+    && pyenv global $PYTHON_39_VERSION \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli boto3 pipenv virtualenv --use-feature=2020-resolver
+
+VOLUME /var/lib/docker
+
+#****************     GO     **********************************************************
+ENV GOLANG_VERSION="1.23.4" \
+    GOLANG_DOWNLOAD_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.4" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+    && apt-get clean \
+    && wget "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+#****************     END GO     **********************************************************
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/ubuntu/5.0/go1.23/amazon-ssm-agent.json
+++ b/ubuntu/5.0/go1.23/amazon-ssm-agent.json
@@ -1,0 +1,45 @@
+{
+    "Profile":{
+        "ShareCreds" : true,
+        "ShareProfile" : ""
+    },
+    "Mds": {
+        "CommandWorkersLimit" : 5,
+        "StopTimeoutMillis" : 20000,
+        "Endpoint": "",
+        "CommandRetryLimit": 15
+    },
+    "Ssm": {
+        "Endpoint": "",
+        "HealthFrequencyMinutes": 5,
+        "CustomInventoryDefaultLocation" : "",
+        "AssociationLogsRetentionDurationHours" : 24,
+        "RunCommandLogsRetentionDurationHours" : 336,
+        "SessionLogsRetentionDurationHours" : 336
+    },
+    "Mgs": {
+        "Region": "",
+        "Endpoint": "",
+        "StopTimeoutMillis" : 20000,
+        "SessionWorkersLimit" : 1000
+    },
+    "Agent": {
+        "Region": "",
+        "OrchestrationRootDir": "",
+        "ContainerMode": true
+    },
+    "Os": {
+        "Lang": "en-US",
+        "Name": "",
+        "Version": "1"
+    },
+    "S3": {
+        "Endpoint": "",
+        "Region": "",
+        "LogBucket":"",
+        "LogKey":""
+    },
+    "Kms": {
+        "Endpoint": ""
+    }
+}

--- a/ubuntu/5.0/go1.23/dockerd-entrypoint.sh
+++ b/ubuntu/5.0/go1.23/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/ubuntu/5.0/go1.23/runtimes.yml
+++ b/ubuntu/5.0/go1.23/runtimes.yml
@@ -1,0 +1,17 @@
+version: 0.1
+
+runtimes:
+
+  golang:
+    versions:
+      1.23:
+        commands:
+          - echo "Installing Go version 1.23 ..."
+  docker:
+    versions:
+      18:
+        commands:
+          - echo "Using Docker 19"
+      19:
+        commands:
+          - echo "Using Docker 19"

--- a/ubuntu/5.0/go1.23/ssh_config
+++ b/ubuntu/5.0/go1.23/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/ubuntu/5.0/go1.23/tools/runtime_configs/python/3.9.5
+++ b/ubuntu/5.0/go1.23/tools/runtime_configs/python/3.9.5
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"  
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.9.5
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tar.xz#0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83" standard verify_py39 copy_python_gdb ensurepip
+else
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz#e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab" standard verify_py39 copy_python_gdb ensurepip
+fi

--- a/update.sh
+++ b/update.sh
@@ -2,41 +2,41 @@
 
 (
     cd ubuntu/3.0 \
+    && echo checking update for 1.23-standard-3.0 >&2 \
+    && ./update.pl 1.23 \
     && echo checking update for 1.22-standard-3.0 >&2 \
     && ./update.pl 1.22 \
-    && echo checking update for 1.21-standard-3.0 >&2 \
-    && ./update.pl 1.21 \
     && true
 ) || exit 1
 (
     cd ubuntu/4.0 \
+    && echo checking update for 1.23-standard-4.0 >&2 \
+    && ./update.pl 1.23 \
     && echo checking update for 1.22-standard-4.0 >&2 \
     && ./update.pl 1.22 \
-    && echo checking update for 1.21-standard-4.0 >&2 \
-    && ./update.pl 1.21 \
     && true
 ) || exit 1
 (
     cd ubuntu/5.0 \
+    && echo checking update for 1.23-standard-5.0 >&2 \
+    && ./update.pl 1.23 \
     && echo checking update for 1.22-standard-5.0 >&2 \
     && ./update.pl 1.22 \
-    && echo checking update for 1.21-standard-5.0 >&2 \
-    && ./update.pl 1.21 \
     && true
 ) || exit 1
 (
     cd al2/2.0 \
+    && echo checking update for 1.23-amazonlinux2-2.0 >&2 \
+    && ./update.pl 1.23 \
     && echo checking update for 1.22-amazonlinux2-2.0 >&2 \
     && ./update.pl 1.22 \
-    && echo checking update for 1.21-amazonlinux2-2.0 >&2 \
-    && ./update.pl 1.21 \
     && true
 ) || exit 1
 (
     cd al2/3.0 \
+    && echo checking update for 1.23-amazonlinux2-3.0 >&2 \
+    && ./update.pl 1.23 \
     && echo checking update for 1.22-amazonlinux2-3.0 >&2 \
     && ./update.pl 1.22 \
-    && echo checking update for 1.21-amazonlinux2-3.0 >&2 \
-    && ./update.pl 1.21 \
     && true
 ) || exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Go version 1.23 support across multiple platforms (Ubuntu, Amazon Linux 2)
	- Updated Docker image configurations for Go 1.23
	- Introduced new runtime configuration files for Go 1.23

- **Infrastructure**
	- Updated GitHub Actions workflows to use Go 1.23 build scripts
	- Added new SSH configuration with improved connection timeout settings
	- Updated README with new Docker image tags for Go 1.23

- **Documentation**
	- Updated documentation to reflect Go 1.23 version support
	- Added new runtime configuration files for various environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->